### PR TITLE
bump semantic ui version to fix compile error

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sass": "1.3.2",
     "sass-loader": "7.0.1",
     "semantic-ui-css": "2.3.1",
-    "semantic-ui-react": "0.80.0",
+    "semantic-ui-react": "0.80.2",
     "style-loader": "0.21.0",
     "ts-loader": "4.3.0",
     "typescript": "2.8.3",


### PR DESCRIPTION
Awesome project 👍 your code is great.

When running this project locally, I got a compile error related to `semantic-ui-react`. I tracked it down to [this issue](https://github.com/Semantic-Org/Semantic-UI-React/issues/2834), and simply bumping the minor version number fixed it.